### PR TITLE
Add manual serial control sketch for cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Ardui
+
+Sketch de ejemplo para controlar un carrito con un controlador de motores
+L298N mediante comandos enviados por el puerto serie.
+
+## Comandos soportados
+
+El archivo `Carrito-sensor-ultrasonido-Blue/carrito.ino` escucha un carácter y
+realiza un movimiento corto:
+
+- `F` &rarr; avance hacia adelante.
+- `B` &rarr; retroceso.
+- `L` &rarr; giro a la izquierda.
+- `R` &rarr; giro a la derecha.
+
+Cualquier otro carácter detiene el carrito.


### PR DESCRIPTION
## Summary
- simplify cart sketch to support only F/B/L/R commands via serial
- document manual commands in README

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno Carrito-sensor-ultrasonido-Blue` *(fails: command not found)*
- `apt-get update` *(fails: repository 'noble' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ee9a97448332a2b573efe42ece3f